### PR TITLE
Fix travis for PHP 7.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
 	"license": "BSD-3-Clause",
 	"description": "Small library for looking up terms by item or property id or findings ids by term",
 	"require": {
-		"php": ">=7.0",
+		"php": "^7.0|^7.1|^7.2",
 		"wikibase/data-model": "~9.1",
 		"doctrine/dbal": "~2.5.13"
 	},

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
 		"phpunit/phpunit": "^6.5.14",
 		"ockcyp/covers-validator": "~1.1",
 		"squizlabs/php_codesniffer": "~3.3",
-		"slevomat/coding-standard": "~4.5",
+		"slevomat/coding-standard": "^3.0|~4.5",
 		"mediawiki/mediawiki-codesniffer": "~23.0",
 		"phpstan/phpstan": "~0.9.2"
 	},


### PR DESCRIPTION
Use ^ instead of >= and list php versions needed